### PR TITLE
feat!: add `delimiter`, `capitalize` and `preset` options, rewrite app and lib

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,4 +14,8 @@ pub struct DicewareCli {
   /// Show entropy of the passphrase.
   #[clap(short, long, display_order = 3)]
   pub entropy: bool,
+
+  /// Delimiter to use for joining words.
+  #[clap(short, long, display_order = 4)]
+  pub delimiter: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[clap(version, about = "Generates strong Diceware passphrases.", long_about = None)]
-pub struct DicewareCli {
+pub struct Cli {
   /// How much words to generate.
   #[clap(short, long, default_value_t = 6, display_order = 1)]
   pub length: usize,
@@ -15,11 +15,15 @@ pub struct DicewareCli {
   #[clap(short, long, display_order = 3)]
   pub entropy: bool,
 
-  /// Delimiter to use for joining words.
+  /// Capitalize words.
   #[clap(short, long, display_order = 4)]
+  pub capitalize: bool,
+
+  /// Delimiter to use for joining words.
+  #[clap(short, long, display_order = 5)]
   pub delimiter: Option<String>,
 
-  /// Whether to capitalize words or not.
-  #[clap(short, long, display_order = 5)]
-  pub capitalize: bool,
+  /// Formatting preset to use.
+  #[clap(short, long, display_order = 6, value_parser = ["pascal", "kebab", "snake"])]
+  pub preset: Option<String>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,4 +18,8 @@ pub struct DicewareCli {
   /// Delimiter to use for joining words.
   #[clap(short, long, display_order = 4)]
   pub delimiter: Option<String>,
+
+  /// Whether to capitalize words or not.
+  #[clap(short, long, display_order = 5)]
+  pub capitalize: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-use std::fs::File;
-use std::io::{BufRead, BufReader, Result};
-use std::path::Path;
-
 use rand::Rng;
 
 static EFF_WORDLIST: &str = include_str!("../data/eff_long_wordlist.txt");
@@ -9,9 +5,209 @@ static EFF_WORDLIST: &str = include_str!("../data/eff_long_wordlist.txt");
 /// Represents a pair of an index, and a word associated with that index.
 pub(crate) type Pair = (usize, String);
 
-/// Given a wordlist and rolls, generates a Diceware passphraseas as a [Vec] of words.
-/// Given a wordlist and rolls, generates a Diceware passphrase as a [Vec] of words.
-pub fn passphrase(lines: Vec<String>, dice_rolls: Vec<Vec<usize>>) -> Vec<String> {
+/// Formatting presets.
+#[derive(Clone, Debug, Default)]
+pub enum Preset {
+  /// Format using `PascalCase` style.
+  PascalCase,
+  /// Format using `kebab-case` style.
+  KebabCase,
+  /// Format using `snake_case` style.
+  SnakeCase,
+  /// Format using provided parameters.
+  Arbitrary {
+    /// Whether to capitalize a word or not.
+    capitalize: bool,
+    /// Delimiter to use when joining words.
+    delimiter: Option<String>,
+  },
+  /// Format using default parameters.
+  #[default]
+  Default,
+}
+
+impl Preset {
+  /// Creates a [Preset] from given string (excepting [Preset::Arbitrary]).
+  pub fn from(preset_name: &str) -> Self {
+    match preset_name {
+      | "pascal" => Self::PascalCase,
+      | "kebab" => Self::KebabCase,
+      | "snake" => Self::SnakeCase,
+      | _ => Self::Default,
+    }
+  }
+}
+
+/// Non-consuming builder that allows to easily configure things up and generate a [Passphrase].
+///
+/// # Examples
+///
+/// You can use method chaining:
+///
+/// ```ignore
+/// let mut builder = Passphraser::new(6)
+///   .wordlist(&wordlist)
+///   .length(10);
+///   .preset(Preset::PascalCase)
+/// ```
+///
+/// Or call them separately:
+///
+/// ```ignore
+/// let mut builder = Passphraser::new(6);
+///
+/// builder.wordlist(&wordlist);
+/// builder.length(10);
+/// builder.preset(Preset::PascalCase);
+///
+/// let passphrase = builder.generate();
+/// ```
+#[derive(Debug)]
+pub struct Passphraser {
+  /// Number of words to generate.
+  length: usize,
+  /// Wordlist to pick words from.
+  wordlist: Vec<String>,
+  /// Formatting preset to use. Default is [Preset::Default].
+  preset: Preset,
+}
+
+impl Passphraser {
+  /// Create builder with specified number of words to generate.
+  pub fn new(length: usize) -> Self {
+    Self {
+      length,
+      wordlist: builtin_wordlist(),
+      preset: Preset::Default,
+    }
+  }
+
+  /// Set the number of words to generate.
+  pub fn length<'a>(&'a mut self, length: usize) -> &'a mut Self {
+    self.length = length;
+    self
+  }
+
+  /// Set the wordlist to pick words from.
+  pub fn wordlist<'a>(&'a mut self, list: &'a [String]) -> &'a mut Self {
+    self.wordlist = list.to_vec();
+    self
+  }
+
+  /// Set the formatting preset.
+  pub fn preset<'a>(&'a mut self, preset: Preset) -> &'a mut Self {
+    self.preset = preset;
+    self
+  }
+
+  /// Roll dice, generate passphrase words, calculate entropy and return a [Passphrase].
+  pub fn generate(&self) -> Passphrase {
+    let rolls = roll_dice(self.length, 5, 1, 6);
+    let words = passphrase(&self.wordlist, rolls);
+
+    let entropy = Entropy::new(self.wordlist.len(), self.length);
+
+    Passphrase {
+      words,
+      preset: self.preset.clone(),
+      entropy,
+    }
+  }
+}
+
+/// Contains information about entropy.
+#[derive(Debug)]
+pub struct Entropy {
+  /// How much unique words (possibilites) contains the wordlist.
+  pub possibilities: usize,
+  /// Calculated entropy of the passphrase.
+  pub entropy: f32,
+}
+
+impl Entropy {
+  pub fn new(possibilities: usize, phrase_length: usize) -> Self {
+    Entropy {
+      possibilities,
+      entropy: calc_entropy(possibilities, phrase_length),
+    }
+  }
+}
+
+/// Contains generated passphrase words, formatting preset and calculated entropy.
+#[derive(Debug)]
+pub struct Passphrase {
+  preset: Preset,
+  entropy: Entropy,
+  words: Vec<String>,
+}
+
+impl Passphrase {
+  const DELIM_DEFAULT: &'static str = " ";
+  const DELIM_KEBABCASE: &'static str = "-";
+  const DELIM_PASCALCASE: &'static str = "";
+  const DELIM_SNAKECASE: &'static str = "_";
+
+  /// Returns generated passphrase words.
+  pub fn words(&self) -> &Vec<String> {
+    &self.words
+  }
+
+  /// Returns calculated passphrase [Entropy].
+  pub fn entropy(&self) -> &Entropy {
+    &self.entropy
+  }
+
+  /// Formats passphrase using the passphrase's preset.
+  pub fn format(&self) -> String {
+    self.format_with(&self.preset)
+  }
+
+  /// Formats passphrase using the given preset.
+  pub fn format_with(&self, preset: &Preset) -> String {
+    match &preset {
+      | Preset::PascalCase => self.format_using(Self::DELIM_PASCALCASE, true),
+      | Preset::KebabCase => self.format_using(Self::DELIM_KEBABCASE, false),
+      | Preset::SnakeCase => self.format_using(Self::DELIM_SNAKECASE, false),
+      | Preset::Arbitrary {
+        capitalize,
+        delimiter,
+      } => {
+        let default = Self::DELIM_DEFAULT.to_string();
+        let delimiter = delimiter.clone().unwrap_or(default);
+
+        self.format_using(&delimiter, *capitalize)
+      },
+      | Preset::Default => self.format_using(Self::DELIM_DEFAULT, false),
+    }
+  }
+
+  /// Joins words using specified delimiter and optionally capitalizes them.
+  fn format_using(&self, delimiter: &str, capitalize: bool) -> String {
+    let words = if capitalize {
+      self
+        .words
+        .iter()
+        .map(|word| to_capitalized(&word))
+        .collect::<Vec<_>>()
+    } else {
+      self.words.clone()
+    };
+
+    words.join(delimiter)
+  }
+}
+
+/// Rolls a dice, producing a vector of numbers for each run.
+pub fn roll_dice(runs: usize, rolls: usize, start: usize, end: usize) -> Vec<Vec<usize>> {
+  let mut rng = rand::thread_rng();
+
+  (1..=runs)
+    .map(|_| (1..=rolls).map(|_| rng.gen_range(start..end)).collect())
+    .collect()
+}
+
+/// Given a wordlist and dice rolls, generates a Diceware passphrase as a [Vec] of words.
+pub fn passphrase(lines: &[String], dice_rolls: Vec<Vec<usize>>) -> Vec<String> {
   let words = dice_rolls.iter().fold(Vec::new(), |acc, roll| {
     let rolled_index = to_index(roll.to_vec());
 
@@ -35,25 +231,8 @@ pub fn passphrase(lines: Vec<String>, dice_rolls: Vec<Vec<usize>>) -> Vec<String
   words
 }
 
-/// Rolls a dice, producing a vector of numbers for each run.
-pub fn roll_dice(runs: usize, rolls: usize, start: usize, end: usize) -> Vec<Vec<usize>> {
-  let mut rng = rand::thread_rng();
-
-  (1..=runs)
-    .map(|_| (1..=rolls).map(|_| rng.gen_range(start..end)).collect())
-    .collect()
-}
-
-/// Reads a wordlist with `<index> <word>` pairs and returns a [Result] with vector of lines.
-pub fn read_wordlist<P: AsRef<Path>>(path: P) -> Result<Vec<String>> {
-  let file = File::open(path)?;
-  let reader = BufReader::new(file);
-
-  reader.lines().collect()
-}
-
 /// Reads a built-in EFF long wordlist and returns a vector of lines.
-pub fn read_wordlist_internal() -> Vec<String> {
+pub fn builtin_wordlist() -> Vec<String> {
   EFF_WORDLIST.lines().map(str::to_string).collect()
 }
 
@@ -89,7 +268,7 @@ pub(crate) fn to_index(ns: Vec<usize>) -> usize {
 }
 
 /// Capitalizes the first char of given string.
-pub fn to_capitalized(s: &str) -> String {
+pub(crate) fn to_capitalized(s: &str) -> String {
   let mut chars = s.chars();
 
   match chars.next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ static EFF_WORDLIST: &str = include_str!("../data/eff_long_wordlist.txt");
 pub(crate) type Pair = (usize, String);
 
 /// Given a wordlist and rolls, generates a Diceware passphraseas as a [Vec] of words.
+/// Given a wordlist and rolls, generates a Diceware passphrase as a [Vec] of words.
 pub fn passphrase(lines: Vec<String>, dice_rolls: Vec<Vec<usize>>) -> Vec<String> {
   let words = dice_rolls.iter().fold(Vec::new(), |acc, roll| {
     let rolled_index = to_index(roll.to_vec());
@@ -85,6 +86,16 @@ pub(crate) fn to_pair(components: Vec<&str>) -> Option<Pair> {
 /// Diceware wordlist.
 pub(crate) fn to_index(ns: Vec<usize>) -> usize {
   ns.iter().fold(0, |acc, n| acc * 10 + n)
+}
+
+/// Capitalizes the first char of given string.
+pub fn to_capitalized(s: &str) -> String {
+  let mut chars = s.chars();
+
+  match chars.next() {
+    | None => String::new(),
+    | Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+  }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl Passphraser {
   }
 
   /// Set the number of words to generate.
-  pub fn length<'a>(&'a mut self, length: usize) -> &'a mut Self {
+  pub fn length(&mut self, length: usize) -> &mut Self {
     self.length = length;
     self
   }
@@ -95,7 +95,7 @@ impl Passphraser {
   }
 
   /// Set the formatting preset.
-  pub fn preset<'a>(&'a mut self, preset: Preset) -> &'a mut Self {
+  pub fn preset(&mut self, preset: Preset) -> &mut Self {
     self.preset = preset;
     self
   }
@@ -187,7 +187,7 @@ impl Passphrase {
       self
         .words
         .iter()
-        .map(|word| to_capitalized(&word))
+        .map(|word| to_capitalized(word))
         .collect::<Vec<_>>()
     } else {
       self.words.clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,15 +25,22 @@ fn main() {
 
   let variants = wordlist.len();
   let rolls = diceware::roll_dice(cli.length, 5, 1, 6);
-  let passphrase = diceware::passphrase(wordlist, rolls);
+  let mut words = diceware::passphrase(wordlist, rolls);
 
-  if passphrase.is_empty() {
+  if words.is_empty() {
     println!("Couldn't generate a passphrase with given parameters.");
     process::exit(1);
   } else {
+    if cli.capitalize {
+      words = words
+        .into_iter()
+        .map(|word| diceware::to_capitalized(&word))
+        .collect::<Vec<_>>();
+    }
+
     let passphrase = match cli.delimiter {
-      | Some(delimiter) => passphrase.join(&delimiter),
-      | None => passphrase.join(" "),
+      | Some(delimiter) => words.join(&delimiter),
+      | None => words.join(" "),
     };
 
     println!("{}", passphrase.green().bold());

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,12 @@ fn main() {
     println!("Couldn't generate a passphrase with given parameters.");
     process::exit(1);
   } else {
-    println!("{}", passphrase.join(" ").green().bold());
+    let passphrase = match cli.delimiter {
+      | Some(delimiter) => passphrase.join(&delimiter),
+      | None => passphrase.join(" "),
+    };
+
+    println!("{}", passphrase.green().bold());
 
     if cli.entropy {
       let possibilities = format!("{}", variants).blue();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
 
   // Trying to load custom wordlist if set.
   if let Some(path) = cli.wordlist {
-    if let Ok(wordlist) = read_wordlist(path.clone()) {
+    if let Ok(wordlist) = read_wordlist(path) {
       builder.wordlist(&wordlist);
     } else {
       println!("Couldn't read the wordlist. Make sure the file exists.");
@@ -46,7 +46,7 @@ fn main() {
   }
 
   // Generate the passphrase.
-  let mut passphrase = builder.preset(preset).generate();
+  let passphrase = builder.preset(preset).generate();
 
   if passphrase.words().is_empty() {
     println!("Couldn't generate a passphrase with given parameters.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,57 +1,76 @@
 mod cli;
 
+use std::fs::File;
+use std::io::{BufRead, BufReader, Result};
+use std::path::Path;
 use std::process;
 
 use clap::Parser;
-use cli::DicewareCli;
+use cli::Cli;
 use colored::*;
+use diceware::{Passphraser, Preset};
 
 fn main() {
-  let cli = DicewareCli::parse();
+  let cli = Cli::parse();
+  let mut builder = Passphraser::new(cli.length);
 
-  let wordlist = {
-    if let Some(path) = cli.wordlist {
-      if let Ok(wordlist) = diceware::read_wordlist(path.clone()) {
-        println!("Using the wordlist: {}\n", path);
-        wordlist
-      } else {
-        println!("Couldn't read the wordlist. Make sure the file exists.");
-        process::exit(1);
-      }
+  // Trying to load custom wordlist if set.
+  if let Some(path) = cli.wordlist {
+    if let Ok(wordlist) = read_wordlist(path.clone()) {
+      builder.wordlist(&wordlist);
     } else {
-      diceware::read_wordlist_internal()
+      println!("Couldn't read the wordlist. Make sure the file exists.");
+      process::exit(1);
     }
+  }
+
+  // Setting a preset for formatting.
+  let mut preset = if let Some(preset) = cli.preset {
+    Preset::from(&preset)
+  } else {
+    Preset::Default
   };
 
-  let variants = wordlist.len();
-  let rolls = diceware::roll_dice(cli.length, 5, 1, 6);
-  let mut words = diceware::passphrase(wordlist, rolls);
+  if cli.capitalize {
+    preset = Preset::Arbitrary {
+      capitalize: cli.capitalize,
+      delimiter: None,
+    }
+  }
 
-  if words.is_empty() {
+  if cli.delimiter.is_some() {
+    preset = Preset::Arbitrary {
+      capitalize: cli.capitalize,
+      delimiter: cli.delimiter,
+    }
+  }
+
+  // Generate the passphrase.
+  let mut passphrase = builder.preset(preset).generate();
+
+  if passphrase.words().is_empty() {
     println!("Couldn't generate a passphrase with given parameters.");
     process::exit(1);
   } else {
-    if cli.capitalize {
-      words = words
-        .into_iter()
-        .map(|word| diceware::to_capitalized(&word))
-        .collect::<Vec<_>>();
-    }
-
-    let passphrase = match cli.delimiter {
-      | Some(delimiter) => words.join(&delimiter),
-      | None => words.join(" "),
-    };
-
-    println!("{}", passphrase.green().bold());
+    println!("{}", &passphrase.format().green().bold());
 
     if cli.entropy {
-      let possibilities = format!("{}", variants).blue();
-      let entropy = format!("{:.2} bits", diceware::calc_entropy(variants, cli.length)).blue();
+      let entropy = passphrase.entropy();
+
+      let possibilities = format!("{}", entropy.possibilities).blue();
+      let entropy = format!("{:.2} bits", entropy.entropy).blue();
 
       println!("\nPossibilities: {possibilities}");
       println!("Entropy: {entropy}");
       println!("\nMore about entropy at https://theworld.com/~reinhold/dicewarefaq.html#entropy");
     }
   }
+}
+
+/// Reads a wordlist with `<index> <word>` pairs and returns a [Result] with vector of lines.
+fn read_wordlist<P: AsRef<Path>>(path: P) -> Result<Vec<String>> {
+  let file = File::open(path)?;
+  let reader = BufReader::new(file);
+
+  reader.lines().collect()
 }


### PR DESCRIPTION
This PR resolves #1.

# CLI

- **delimiter**: Allows to specify any delimiter that will be used to join passphase words. Can be set to an empty string. Defaults to a single space.
- **capitalize**: Allows to capitalize words. Defaults to `false`.
- **preset**: Allows to specify a formatting preset. Formatting presets basically apply a combination of **delimiter** and **capitalize** to passphrase words. There are 3 presets:
  - **pascal** aka PascalCase. Example: `ReliablyAgnosticIcinessAttributeBarrelAlarm`;
  - **kebab** aka kebab-case. Example: `reliably-agnostic-iciness-attribute-barrel-alarm`;
  - **snake** aka snake_case. Example: `reliably_agnostic_iciness_attribute_barrel_alarm`.

  Technically, there's also the default one:

  - **default**. Example: `reliably agnostic iciness attribute barrel alarm`;
  
  Note: **delimiter** and **capitalize** can't be used with **preset**.

# Library

I rewrote the library so it now exposes, in addition to everything else:

- **Passphraser**: non-consuming builder that allows to easily configure things up and generate a **Passphrase**.
- **Passphrase**: contains generated words, calculated entropy and formatting preset.
- **Preset**: formatting presets allow to format generated passphrase words using predefined/specified `delimiter` and `capitalize`.
- **Entropy**: contains information about entropy.